### PR TITLE
fix(normalize): missing col after rowspan is properly normalized

### DIFF
--- a/lib/validation/createNormalizeNode.js
+++ b/lib/validation/createNormalizeNode.js
@@ -48,7 +48,8 @@ export default function(options) {
 								} else if (row.size !== maxColumns) {
 									const numberOfCellsToAdd = maxColumns - row.size
 									const cells = Array.from({ length: numberOfCellsToAdd }).map(() => createCellNode({ blocks }))
-									const insertRow = node.getParent(row.last().ref.key)
+									const firstNonVirtualNode = row.find(node => node && !node.virtual)
+									const insertRow = node.getParent(firstNonVirtualNode.ref.key)
 									cells.forEach(cell => editor.insertNodeByKey(insertRow.key, insertRow.nodes.size, cell))
 								}
 							}


### PR DESCRIPTION
The issue would arise when a row, typically the last one,
did have some missing cells, and had a column above with a rowspan,
meaning that the normalization would add a extra cell the previous row
instead of the current one, resulting in a infinite loop since that extra
(empty) cell would be removed at the next iteration