### PR TITLE
Fix crash & optimise perfs

### DIFF
--- a/lib/commands/decreaseRowspanAtKey.js
+++ b/lib/commands/decreaseRowspanAtKey.js
@@ -9,7 +9,7 @@ export default function decreaseRowspanAtKey({ blocks }, editor, key) {
 		editor.setNodeByKey(cell.key, {
 			data: cell.data.set('rowspan', getCellRowspan(cell) - 1)
 		})
-		let coords = table.getCellCoordinates(cell)
+		const coords = table.getCellCoordinates(cell)
 
 		const lastCoord = coords.maxBy(c => c.y)
 		const cellBelow = table.matrix.has(lastCoord + 1) ? table.matrix.get(lastCoord + 1).get(lastCoord.x) : null

--- a/lib/queries/canDecreaseColspanAtKey.js
+++ b/lib/queries/canDecreaseColspanAtKey.js
@@ -1,7 +1,12 @@
 import { getCellColspan } from '../utils'
 
 export default function canDrecreaseColspanAtKey(options, editor, key) {
-	const table = editor.getTableAtKey(key)
+	try {
+		const table = editor.getTableAtKey(key)
 
-	return getCellColspan(table.cell) > 1
+		return getCellColspan(table.cell) > 1
+	} catch (err) {
+		console.error(err)
+		return false
+	}
 }

--- a/lib/queries/canDecreaseRowspanAtKey.js
+++ b/lib/queries/canDecreaseRowspanAtKey.js
@@ -1,7 +1,12 @@
 import { getCellRowspan } from '../utils'
 
 export default function canDrecreaseRowspanAtKey(options, editor, key) {
-	const table = editor.getTableAtKey(key)
+	try {
+		const table = editor.getTableAtKey(key)
 
-	return getCellRowspan(table.cell) > 1
+		return getCellRowspan(table.cell) > 1
+	} catch (err) {
+		console.error(err)
+		return false
+	}
 }

--- a/lib/queries/canIncreaseColspanAtKey.js
+++ b/lib/queries/canIncreaseColspanAtKey.js
@@ -1,13 +1,18 @@
 import { getCellRowspan } from '../utils'
 
 export default function canIncreaseColspanAtKey({ blocks }, editor, key) {
-	const table = editor.getTableAtKey(key)
-	const { row, cell, nextCell } = table
-	if (row.nodes.last() === cell) {
-		return false
-	}
+	try {
+		const table = editor.getTableAtKey(key)
+		const { row, cell, nextCell } = table
+		if (row.nodes.last() === cell) {
+			return false
+		}
 
-	if (getCellRowspan(cell) !== getCellRowspan(nextCell)) {
+		if (getCellRowspan(cell) !== getCellRowspan(nextCell)) {
+			return false
+		}
+	} catch (err) {
+		console.error(err)
 		return false
 	}
 

--- a/lib/queries/canIncreaseRowspanAtKey.js
+++ b/lib/queries/canIncreaseRowspanAtKey.js
@@ -1,12 +1,17 @@
 import { getCellColspan } from '../utils'
 
 export default function canIncreaseRowspanAtKey({ blocks }, editor, key) {
-	const table = editor.getTableAtKey(key)
-	const { cell } = table
-	const cellBelow = table.getCellBelow()
-	if (!cellBelow) return false
+	try {
+		const table = editor.getTableAtKey(key)
+		const { cell } = table
+		const cellBelow = table.getCellBelow()
+		if (!cellBelow) return false
 
-	if (getCellColspan(cell) !== getCellColspan(cellBelow)) {
+		if (getCellColspan(cell) !== getCellColspan(cellBelow)) {
+			return false
+		}
+	} catch (err) {
+		console.error(err)
 		return false
 	}
 

--- a/lib/queries/isRangeInTable.js
+++ b/lib/queries/isRangeInTable.js
@@ -1,9 +1,6 @@
 export default function isRangeInTable(options, editor, range) {
-	const { start, end } = range
 	try {
-		const startPosition = editor.getTableAtKey(start.key)
-		const endPosition = editor.getTableAtKey(end.key)
-		return startPosition.table === endPosition.table
+		return editor.value.document.getFurthestBlock(range.start.key)?.type === options.blocks.table
 	} catch {
 		return false
 	}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -75,14 +75,17 @@ export class Table extends Record({
 	static create(options, containerNode, key) {
 		const node = containerNode.getDescendant(key)
 		const ancestors = containerNode.getAncestors(key).push(node)
-		const tableBlock = ancestors.findLast((p) => p.type === options.blocks.table)
-		const rowBlock = ancestors.findLast((p) => p.type === options.blocks.row)
-		const cellBlock = ancestors.findLast((p) => p.type === options.blocks.cell)
+		const tableBlock = ancestors.findLast(p => p.type === options.blocks.table)
+		const rowBlock = ancestors.findLast(p => p.type === options.blocks.row)
+		const cellBlock = ancestors.findLast(p => p.type === options.blocks.cell)
 		const contentBlock = ancestors
-			.skipUntil((ancestor) => ancestor === cellBlock)
+			.skipUntil(ancestor => ancestor === cellBlock)
 			.skip(1)
 			.first()
 
+		if (!tableBlock) {
+			throw new Error('Not in a table')
+		}
 		const matrix = createMatrix(tableBlock)
 
 		return new Table({ tableBlock, rowBlock, cellBlock, contentBlock, matrix })
@@ -134,6 +137,7 @@ export class Table extends Record({
 
 		const { matrix, cell: current } = this
 		const coord = this.getCellCoordinates(current).first()
+		if (!coord) return null
 		let x = coord.x
 		let y = coord.y
 		while (matrix.has(y) && matrix.get(y).has(x)) {
@@ -156,6 +160,7 @@ export class Table extends Record({
 		if (this.isFirstRow()) return null
 		const { matrix, cell } = this
 		const pos = this.getCellCoordinates(cell).first()
+		if (!pos) return null
 		let y = pos.y
 		while (y-- > 0) {
 			if (!matrix.has(y)) return
@@ -172,6 +177,7 @@ export class Table extends Record({
 		if (this.isLastRow()) return null
 		const { matrix, cell } = this
 		const pos = this.getCellCoordinates(cell).first()
+		if (!pos) return null
 		let y = pos.y
 		while (y++ < matrix.size) {
 			if (!matrix.has(y)) return
@@ -251,12 +257,12 @@ export class Table extends Record({
 		const { table, row } = this
 		const rows = table.nodes
 
-		return rows.findIndex((x) => x === row)
+		return rows.findIndex(x => x === row)
 	}
 
 	getCellStartColumn() {
 		const { cell } = this
-		return this.row.nodes.takeUntil((c) => c === cell).reduce((acc, c) => acc + getCellColspan(c), 0)
+		return this.row.nodes.takeUntil(c => c === cell).reduce((acc, c) => acc + getCellColspan(c), 0)
 	}
 
 	/**


### PR DESCRIPTION
- Prevent errors to break the editor.
- Drastically improve isRangeInTable by not recreating 2 tables on each call.
This function is called a lot in the editor and was recreating two times
each table.